### PR TITLE
Fix drops for leaves, close #1821

### DIFF
--- a/src/pocketmine/block/Leaves.php
+++ b/src/pocketmine/block/Leaves.php
@@ -173,19 +173,19 @@ class Leaves extends Transparent{
 	}
 
 	public function getDrops(Item $item) : array{
-		if(!$this->isCompatibleWithTool($item)){
-			$drops = [];
-			if(mt_rand(1, 20) === 1){ //Saplings
-				$drops[] = $this->getSaplingItem();
-			}
-			if($this->canDropApples() and mt_rand(1, 200) === 1){ //Apples
-				$drops[] = ItemFactory::get(Item::APPLE);
-			}
-
-			return $drops;
+		if($item->getBlockToolType() & BlockToolType::TYPE_SHEARS){
+			return $this->getDropsForCompatibleTool($item);
 		}
 
-		return parent::getDrops($item);
+		$drops = [];
+		if(mt_rand(1, 20) === 1){ //Saplings
+			$drops[] = $this->getSaplingItem();
+		}
+		if($this->canDropApples() and mt_rand(1, 200) === 1){ //Apples
+			$drops[] = ItemFactory::get(Item::APPLE);
+		}
+
+		return $drops;
 	}
 
 	public function getSaplingItem() : Item{


### PR DESCRIPTION
Seems that leaves are another special case - they technically speaking accept any tool to break, but only drop when shears are used. They don't REQUIRE shears because if they did the break time would be longer for non-shears tools.

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
